### PR TITLE
feat(storage): introduced browser-storage as common super-class

### DIFF
--- a/packages/analytics-browser/src/storage/browser-storage.ts
+++ b/packages/analytics-browser/src/storage/browser-storage.ts
@@ -1,0 +1,69 @@
+import { Storage as AmplitudeStorage } from '@amplitude/analytics-types';
+
+export class BrowserStorage<T> implements AmplitudeStorage<T> {
+  constructor(private storage?: Storage) {}
+
+  async isEnabled(): Promise<boolean> {
+    /* istanbul ignore if */
+    if (!this.storage) {
+      return false;
+    }
+
+    const random = String(Date.now());
+    const testStorage = new BrowserStorage<string>(this.storage);
+    const testKey = 'AMP_TEST';
+    try {
+      await testStorage.set(testKey, random);
+      const value = await testStorage.get(testKey);
+      return value === random;
+    } catch {
+      /* istanbul ignore next */
+      return false;
+    } finally {
+      await testStorage.remove(testKey);
+    }
+  }
+
+  async get(key: string): Promise<T | undefined> {
+    try {
+      const value = await this.getRaw(key);
+      if (!value) {
+        return undefined;
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return JSON.parse(value);
+    } catch {
+      console.error(`[Amplitude] Error: Could not get value from storage`);
+      /* istanbul ignore next */
+      return undefined;
+    }
+  }
+
+  async getRaw(key: string): Promise<string | undefined> {
+    return this.storage?.getItem(key) || undefined;
+  }
+
+  async set(key: string, value: T): Promise<void> {
+    try {
+      this.storage?.setItem(key, JSON.stringify(value));
+    } catch {
+      //
+    }
+  }
+
+  async remove(key: string): Promise<void> {
+    try {
+      this.storage?.removeItem(key);
+    } catch {
+      //
+    }
+  }
+
+  async reset(): Promise<void> {
+    try {
+      this.storage?.clear();
+    } catch {
+      //
+    }
+  }
+}

--- a/packages/analytics-browser/src/storage/local-storage.ts
+++ b/packages/analytics-browser/src/storage/local-storage.ts
@@ -1,67 +1,8 @@
 import { getGlobalScope } from '@amplitude/analytics-client-common';
-import { Storage } from '@amplitude/analytics-types';
+import { BrowserStorage } from './browser-storage';
 
-export class LocalStorage<T> implements Storage<T> {
-  async isEnabled(): Promise<boolean> {
-    /* istanbul ignore if */
-    if (!getGlobalScope()) {
-      return false;
-    }
-
-    const random = String(Date.now());
-    const testStorage = new LocalStorage<string>();
-    const testKey = 'AMP_TEST';
-    try {
-      await testStorage.set(testKey, random);
-      const value = await testStorage.get(testKey);
-      return value === random;
-    } catch {
-      /* istanbul ignore next */
-      return false;
-    } finally {
-      await testStorage.remove(testKey);
-    }
-  }
-
-  async get(key: string): Promise<T | undefined> {
-    try {
-      const value = await this.getRaw(key);
-      if (!value) {
-        return undefined;
-      }
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return JSON.parse(value);
-    } catch {
-      /* istanbul ignore next */
-      return undefined;
-    }
-  }
-
-  async getRaw(key: string): Promise<string | undefined> {
-    return getGlobalScope()?.localStorage.getItem(key) || undefined;
-  }
-
-  async set(key: string, value: T): Promise<void> {
-    try {
-      getGlobalScope()?.localStorage.setItem(key, JSON.stringify(value));
-    } catch {
-      //
-    }
-  }
-
-  async remove(key: string): Promise<void> {
-    try {
-      getGlobalScope()?.localStorage.removeItem(key);
-    } catch {
-      //
-    }
-  }
-
-  async reset(): Promise<void> {
-    try {
-      getGlobalScope()?.localStorage.clear();
-    } catch {
-      //
-    }
+export class LocalStorage<T> extends BrowserStorage<T> {
+  constructor() {
+    super(getGlobalScope()?.localStorage);
   }
 }

--- a/packages/analytics-browser/src/storage/session-storage.ts
+++ b/packages/analytics-browser/src/storage/session-storage.ts
@@ -1,67 +1,8 @@
 import { getGlobalScope } from '@amplitude/analytics-client-common';
-import { Storage } from '@amplitude/analytics-types';
+import { BrowserStorage } from './browser-storage';
 
-export class SessionStorage<T> implements Storage<T> {
-  async isEnabled(): Promise<boolean> {
-    /* istanbul ignore if */
-    if (!getGlobalScope()) {
-      return false;
-    }
-
-    const random = String(Date.now());
-    const testStorage = new SessionStorage<string>();
-    const testKey = 'AMP_TEST';
-    try {
-      await testStorage.set(testKey, random);
-      const value = await testStorage.get(testKey);
-      return value === random;
-    } catch {
-      /* istanbul ignore next */
-      return false;
-    } finally {
-      await testStorage.remove(testKey);
-    }
-  }
-
-  async get(key: string): Promise<T | undefined> {
-    try {
-      const value = await this.getRaw(key);
-      if (!value) {
-        return undefined;
-      }
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return JSON.parse(value);
-    } catch {
-      /* istanbul ignore next */
-      return undefined;
-    }
-  }
-
-  async getRaw(key: string): Promise<string | undefined> {
-    return getGlobalScope()?.sessionStorage.getItem(key) || undefined;
-  }
-
-  async set(key: string, value: T): Promise<void> {
-    try {
-      getGlobalScope()?.sessionStorage.setItem(key, JSON.stringify(value));
-    } catch {
-      //
-    }
-  }
-
-  async remove(key: string): Promise<void> {
-    try {
-      getGlobalScope()?.sessionStorage.removeItem(key);
-    } catch {
-      //
-    }
-  }
-
-  async reset(): Promise<void> {
-    try {
-      getGlobalScope()?.sessionStorage.clear();
-    } catch {
-      //
-    }
+export class SessionStorage<T> extends BrowserStorage<T> {
+  constructor() {
+    super(getGlobalScope()?.sessionStorage);
   }
 }

--- a/packages/analytics-browser/test/storage/browser-storage.test.ts
+++ b/packages/analytics-browser/test/storage/browser-storage.test.ts
@@ -1,0 +1,81 @@
+import { BrowserStorage } from '../../src/storage/browser-storage';
+import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
+import { getGlobalScope } from '@amplitude/analytics-client-common';
+
+describe('browser-storage', () => {
+  describe('isEnabled', () => {
+    test('should return true', async () => {
+      const sessionStorage = new BrowserStorage(getGlobalScope()?.sessionStorage);
+      expect(await sessionStorage.isEnabled()).toBe(true);
+    });
+  });
+
+  describe('get', () => {
+    test('should return undefined if not set', async () => {
+      const sessionStorage = new BrowserStorage(getGlobalScope()?.sessionStorage);
+      expect(await sessionStorage.get('1')).toBe(undefined);
+    });
+
+    test('should return object', async () => {
+      const sessionStorage = new BrowserStorage<Record<string, number>>(getGlobalScope()?.sessionStorage);
+      await sessionStorage.set('1', { a: 1 });
+      expect(await sessionStorage.get('1')).toEqual({ a: 1 });
+    });
+
+    test('should return array', async () => {
+      const sessionStorage = new BrowserStorage<number[]>(getGlobalScope()?.sessionStorage);
+      await sessionStorage.set('1', [1]);
+      expect(await sessionStorage.get('1')).toEqual([1]);
+    });
+  });
+
+  describe('set', () => {
+    test('should set value', async () => {
+      const sessionStorage = new BrowserStorage(getGlobalScope()?.sessionStorage);
+      await sessionStorage.set('1', 'a');
+      expect(await sessionStorage.get('1')).toBe('a');
+    });
+  });
+
+  describe('remove', () => {
+    test('should remove value of key', async () => {
+      const sessionStorage = new BrowserStorage(getGlobalScope()?.sessionStorage);
+      await sessionStorage.set('1', 'a');
+      await sessionStorage.set('2', 'b');
+      expect(await sessionStorage.get('1')).toBe('a');
+      expect(await sessionStorage.get('2')).toBe('b');
+      await sessionStorage.remove('1');
+      expect(await sessionStorage.get('1')).toBe(undefined);
+      expect(await sessionStorage.get('2')).toBe('b');
+    });
+
+    test('should handle when GlobalScope is not defined', async () => {
+      const sessionStorage = new BrowserStorage<number[]>(undefined);
+      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
+      await sessionStorage.set('1', [1]);
+      expect(await sessionStorage.get('1')).toEqual(undefined);
+      await sessionStorage.remove('1');
+    });
+  });
+
+  describe('reset', () => {
+    test('should remove all values', async () => {
+      const sessionStorage = new BrowserStorage(getGlobalScope()?.sessionStorage);
+      await sessionStorage.set('1', 'a');
+      await sessionStorage.set('2', 'b');
+      expect(await sessionStorage.get('1')).toBe('a');
+      expect(await sessionStorage.get('2')).toBe('b');
+      await sessionStorage.reset();
+      expect(await sessionStorage.get('1')).toBe(undefined);
+      expect(await sessionStorage.get('2')).toBe(undefined);
+    });
+
+    test('should handle when GlobalScope is not defined', async () => {
+      const sessionStorage = new BrowserStorage<number[]>(undefined);
+      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
+      await sessionStorage.set('1', [1]);
+      expect(await sessionStorage.get('1')).toEqual(undefined);
+      await sessionStorage.reset();
+    });
+  });
+});

--- a/packages/analytics-browser/test/storage/local-storage.test.ts
+++ b/packages/analytics-browser/test/storage/local-storage.test.ts
@@ -2,79 +2,14 @@ import { LocalStorage } from '../../src/storage/local-storage';
 import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
 
 describe('local-storage', () => {
-  describe('isEnabled', () => {
-    test('should return true', async () => {
-      const localStorage = new LocalStorage();
-      expect(await localStorage.isEnabled()).toBe(true);
-    });
+  test('should return true if storage is available', async () => {
+    const localStorage = new LocalStorage();
+    expect(await localStorage.isEnabled()).toBe(true);
   });
 
-  describe('get', () => {
-    test('should return undefined if not set', async () => {
-      const localStorage = new LocalStorage();
-      expect(await localStorage.get('1')).toBe(undefined);
-    });
-
-    test('should return object', async () => {
-      const localStorage = new LocalStorage<Record<string, number>>();
-      await localStorage.set('1', { a: 1 });
-      expect(await localStorage.get('1')).toEqual({ a: 1 });
-    });
-
-    test('should return array', async () => {
-      const localStorage = new LocalStorage<number[]>();
-      await localStorage.set('1', [1]);
-      expect(await localStorage.get('1')).toEqual([1]);
-    });
-  });
-
-  describe('set', () => {
-    test('should set value', async () => {
-      const localStorage = new LocalStorage();
-      await localStorage.set('1', 'a');
-      expect(await localStorage.get('1')).toBe('a');
-    });
-  });
-
-  describe('remove', () => {
-    test('should remove value of key', async () => {
-      const localStorage = new LocalStorage();
-      await localStorage.set('1', 'a');
-      await localStorage.set('2', 'b');
-      expect(await localStorage.get('1')).toBe('a');
-      expect(await localStorage.get('2')).toBe('b');
-      await localStorage.remove('1');
-      expect(await localStorage.get('1')).toBe(undefined);
-      expect(await localStorage.get('2')).toBe('b');
-    });
-
-    test('should handle when GlobalScope is not defined', async () => {
-      const localStorage = new LocalStorage<number[]>();
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
-      await localStorage.set('1', [1]);
-      expect(await localStorage.get('1')).toEqual(undefined);
-      await localStorage.remove('1');
-    });
-  });
-
-  describe('reset', () => {
-    test('should remove all values', async () => {
-      const localStorage = new LocalStorage();
-      await localStorage.set('1', 'a');
-      await localStorage.set('2', 'b');
-      expect(await localStorage.get('1')).toBe('a');
-      expect(await localStorage.get('2')).toBe('b');
-      await localStorage.reset();
-      expect(await localStorage.get('1')).toBe(undefined);
-      expect(await localStorage.get('2')).toBe(undefined);
-    });
-
-    test('should handle when GlobalScope is not defined', async () => {
-      const localStorage = new LocalStorage<number[]>();
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
-      await localStorage.set('1', [1]);
-      expect(await localStorage.get('1')).toEqual(undefined);
-      await localStorage.reset();
-    });
+  test('should return false if storage is unavailable', async () => {
+    jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
+    const localStorage = new LocalStorage();
+    expect(await localStorage.isEnabled()).toBe(false);
   });
 });

--- a/packages/analytics-browser/test/storage/session-storage.test.ts
+++ b/packages/analytics-browser/test/storage/session-storage.test.ts
@@ -1,80 +1,15 @@
 import { SessionStorage } from '../../src/storage/session-storage';
 import * as AnalyticsClientCommon from '@amplitude/analytics-client-common';
 
-describe('local-storage', () => {
-  describe('isEnabled', () => {
-    test('should return true', async () => {
-      const sessionStorage = new SessionStorage();
-      expect(await sessionStorage.isEnabled()).toBe(true);
-    });
+describe('session-storage', () => {
+  test('should return true if storage is available', async () => {
+    const sessionStorage = new SessionStorage();
+    expect(await sessionStorage.isEnabled()).toBe(true);
   });
 
-  describe('get', () => {
-    test('should return undefined if not set', async () => {
-      const sessionStorage = new SessionStorage();
-      expect(await sessionStorage.get('1')).toBe(undefined);
-    });
-
-    test('should return object', async () => {
-      const sessionStorage = new SessionStorage<Record<string, number>>();
-      await sessionStorage.set('1', { a: 1 });
-      expect(await sessionStorage.get('1')).toEqual({ a: 1 });
-    });
-
-    test('should return array', async () => {
-      const sessionStorage = new SessionStorage<number[]>();
-      await sessionStorage.set('1', [1]);
-      expect(await sessionStorage.get('1')).toEqual([1]);
-    });
-  });
-
-  describe('set', () => {
-    test('should set value', async () => {
-      const sessionStorage = new SessionStorage();
-      await sessionStorage.set('1', 'a');
-      expect(await sessionStorage.get('1')).toBe('a');
-    });
-  });
-
-  describe('remove', () => {
-    test('should remove value of key', async () => {
-      const sessionStorage = new SessionStorage();
-      await sessionStorage.set('1', 'a');
-      await sessionStorage.set('2', 'b');
-      expect(await sessionStorage.get('1')).toBe('a');
-      expect(await sessionStorage.get('2')).toBe('b');
-      await sessionStorage.remove('1');
-      expect(await sessionStorage.get('1')).toBe(undefined);
-      expect(await sessionStorage.get('2')).toBe('b');
-    });
-
-    test('should handle when GlobalScope is not defined', async () => {
-      const sessionStorage = new SessionStorage<number[]>();
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
-      await sessionStorage.set('1', [1]);
-      expect(await sessionStorage.get('1')).toEqual(undefined);
-      await sessionStorage.remove('1');
-    });
-  });
-
-  describe('reset', () => {
-    test('should remove all values', async () => {
-      const sessionStorage = new SessionStorage();
-      await sessionStorage.set('1', 'a');
-      await sessionStorage.set('2', 'b');
-      expect(await sessionStorage.get('1')).toBe('a');
-      expect(await sessionStorage.get('2')).toBe('b');
-      await sessionStorage.reset();
-      expect(await sessionStorage.get('1')).toBe(undefined);
-      expect(await sessionStorage.get('2')).toBe(undefined);
-    });
-
-    test('should handle when GlobalScope is not defined', async () => {
-      const sessionStorage = new SessionStorage<number[]>();
-      jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
-      await sessionStorage.set('1', [1]);
-      expect(await sessionStorage.get('1')).toEqual(undefined);
-      await sessionStorage.reset();
-    });
+  test('should return false if storage is unavailable', async () => {
+    jest.spyOn(AnalyticsClientCommon, 'getGlobalScope').mockReturnValue(undefined);
+    const sessionStorage = new SessionStorage();
+    expect(await sessionStorage.isEnabled()).toBe(false);
   });
 });


### PR DESCRIPTION
localStorage and sessionStorage both implement the window.Storage interface

By passing the desired storage into browser-storage we avoid duplicating code

<!---
Thanks for contributing to the Amplitude TypeScript repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-TypeScript/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
